### PR TITLE
Refactor tests

### DIFF
--- a/android/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
+++ b/android/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
@@ -18,10 +18,10 @@ package com.google.common.cache;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -36,7 +36,7 @@ import junit.framework.TestCase;
 public class CacheLoaderTest extends TestCase {
 
   private static class QueuingExecutor implements Executor {
-    private LinkedList<Runnable> tasks = Lists.newLinkedList();
+    private ArrayDeque<Runnable> tasks = Queues.newArrayDeque();
 
     @Override
     public void execute(Runnable task) {

--- a/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
+++ b/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
@@ -18,10 +18,10 @@ package com.google.common.cache;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -36,7 +36,7 @@ import junit.framework.TestCase;
 public class CacheLoaderTest extends TestCase {
 
   private static class QueuingExecutor implements Executor {
-    private LinkedList<Runnable> tasks = Lists.newLinkedList();
+    private ArrayDeque<Runnable> tasks = Queues.newArrayDeque();
 
     @Override
     public void execute(Runnable task) {


### PR DESCRIPTION
Refactor CacheLoaderTest to use ArrayDeque instead of LinkedList, in /guava and /android.

Co-authored-by: Caroline Larsen <e.caroline.larsen@gmail.com>
Co-authored-by: Joakim Skoog <joakim.skoog.97@gmail.com>